### PR TITLE
Increase print width to 100 on Prettier settings

### DIFF
--- a/packages/etherumjs-config-prettier/prettier.json
+++ b/packages/etherumjs-config-prettier/prettier.json
@@ -1,4 +1,5 @@
 {
+  "printWidth": 100,
   "tabWidth": 2,
   "semi": false,
   "singleQuote": true,


### PR DESCRIPTION
Ok ok, I realized on my ``ethereumjs-common`` [TypeScript update work](https://github.com/ethereumjs/ethereumjs-common/pull/38) that this default ``80`` character settings kills (ok: line-breaks) even method signature lines like:

```TypeScript
constructor (chain: chainType, hardfork: string | null, supportedHardforks: Array<string>) {
```

especially with this additional type information taking extra space. Since we had this [discussion](https://github.com/ethereumjs/rlp/pull/41#discussion_r232954064) already I will last-minute-inject this here and also approve, since @krzkaczor was positive on this and me actually preventing in first round.
