### PR TITLE
Add endOfLine option to Prettier config

### DIFF
--- a/packages/ethereumjs-config-prettier/prettier.json
+++ b/packages/ethereumjs-config-prettier/prettier.json
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "lf",
   "printWidth": 100,
   "tabWidth": 2,
   "semi": false,


### PR DESCRIPTION
This PR adds the [`endOfLine`](https://prettier.io/docs/en/options.html#end-of-line) option to the Prettier config to normalize line endings going forward.