### PR TITLE
Added CLI scripts

### DIFF
--- a/packages/ethereumjs-config-nyc/README.md
+++ b/packages/ethereumjs-config-nyc/README.md
@@ -1,0 +1,34 @@
+#@ethereumjs/config-nyc
+
+Common test coverage configuration for `EthereumJS` libraries.
+
+Tool: [nyc](https://istanbul.js.org/)
+
+Supported Version: `^11.7.0`
+
+Exposed CLI commands:
+
+- `ethereumjs-config-coverage`
+- `ethereumjs-config-coveralls`
+
+## Usage
+
+Add `.nycrc`:
+
+```json
+{
+  "extends": "@ethereumjs/config-nyc"
+}
+```
+
+Use CLI commands above in `package.json`:
+
+```json
+  "scripts": {
+    "coverage": "ethereumjs-config-coverage",
+    "coveralls": "ethereumjs-config-coveralls"
+  }
+```
+
+
+

--- a/packages/ethereumjs-config-nyc/cli/coverage.sh
+++ b/packages/ethereumjs-config-nyc/cli/coverage.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nyc npm run test && exec nyc report --reporter=text-lcov > .nyc_output/lcov.info

--- a/packages/ethereumjs-config-nyc/cli/coveralls.sh
+++ b/packages/ethereumjs-config-nyc/cli/coveralls.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec npm run coverage && exec coveralls <.nyc_output/lcov.info

--- a/packages/ethereumjs-config-nyc/package.json
+++ b/packages/ethereumjs-config-nyc/package.json
@@ -6,8 +6,13 @@
   "repository": "git@github.com:ethereumjs/ethereumjs-config.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
-    "nyc.json"
+    "nyc.json",
+    "cli"
   ],
+  "bin": {
+    "ethereumjs-config-coverage": "./cli/coverage.sh",
+    "ethereumjs-config-coveralls": "./cli/coveralls.sh"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ethereumjs-config-prettier/README.md
+++ b/packages/ethereumjs-config-prettier/README.md
@@ -1,0 +1,42 @@
+#@ethereumjs/config-prettier
+
+Common formatting configuration for `EthereumJS` libraries.
+
+Tool: [Prettier](https://prettier.io/)
+
+Supported Version: `^1.15.3`
+
+Exposed CLI commands:
+
+- `ethereumjs-config-format`
+- `ethereumjs-config-format-fix`
+
+## Usage
+
+Add `prettier.config.js`:
+
+```javascript
+module.exports = require('@ethereumjs/config-prettier')
+```
+
+Add `.prettierignore`:
+
+```shell
+node_modules
+.vscode
+package.json
+dist
+.nyc_output
+```
+
+Use CLI commands above in `package.json`:
+
+```json
+  "scripts": {
+    "format": "ethereumjs-config-format",
+    "format-fix": "ethereumjs-config-format-fix"
+  }
+```
+
+
+

--- a/packages/ethereumjs-config-prettier/cli/format-fix.sh
+++ b/packages/ethereumjs-config-prettier/cli/format-fix.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec prettier --write '**/*.{ts,json,md}'

--- a/packages/ethereumjs-config-prettier/cli/format.sh
+++ b/packages/ethereumjs-config-prettier/cli/format.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec prettier --list-different '**/*.{ts,json,md}'

--- a/packages/ethereumjs-config-prettier/package.json
+++ b/packages/ethereumjs-config-prettier/package.json
@@ -6,8 +6,13 @@
   "repository": "git@github.com:ethereumjs/ethereumjs-config.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
-    "prettier.json"
+    "prettier.json",
+    "cli"
   ],
+  "bin": {
+    "ethereumjs-config-format": "./cli/format.sh",
+    "ethereumjs-config-format-fix": "./cli/format-fix.sh"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ethereumjs-config-tsc/README.md
+++ b/packages/ethereumjs-config-tsc/README.md
@@ -1,0 +1,47 @@
+#@ethereumjs/config-tsc
+
+Common `TypeScript` configuration for `EthereumJS` libraries.
+
+Tool: [TypeScript](https://www.typescriptlang.org/)
+
+Supported Version: `^3.2.2`
+
+Exposed CLI commands:
+
+- `ethereumjs-config-tsc`
+- `ethereumjs-config-build`
+
+## Usage
+
+Add `tsconfig.json`:
+
+```json
+{
+  "extends": "@ethereumjs/config-tsc",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+```
+
+Add `tsconfig.prod.json`:
+
+```json
+{
+  "extends": "@ethereumjs/config-tsc",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+Use CLI commands above in `package.json`:
+
+```json
+  "scripts": {
+    "tsc": "ethereumjs-config-tsc",
+    "build": "ethereumjs-config-build"
+  }
+```
+
+
+

--- a/packages/ethereumjs-config-tsc/cli/build.sh
+++ b/packages/ethereumjs-config-tsc/cli/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tsc -p ./tsconfig.prod.json

--- a/packages/ethereumjs-config-tsc/cli/tsc.sh
+++ b/packages/ethereumjs-config-tsc/cli/tsc.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tsc --noEmit

--- a/packages/ethereumjs-config-tsc/package.json
+++ b/packages/ethereumjs-config-tsc/package.json
@@ -6,8 +6,13 @@
   "repository": "git@github.com:ethereumjs/ethereumjs-config.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
-    "tsconfig.json"
+    "tsconfig.json",
+    "cli"
   ],
+  "bin": {
+    "ethereumjs-config-tsc": "./cli/tsc.sh",
+    "ethereumjs-config-build": "./cli/build.sh"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ethereumjs-config-tslint/README.md
+++ b/packages/ethereumjs-config-tslint/README.md
@@ -1,0 +1,38 @@
+#@ethereumjs/config-tslint
+
+Common linting configuration for `EthereumJS` libraries.
+
+Tool: [TSLint](https://palantir.github.io/tslint/)
+
+Supported Version: `^5.12.0`
+
+Exposed CLI commands:
+
+- `ethereumjs-config-tslint`
+- `ethereumjs-config-tslint-fix`
+- `ethereumjs-config-lint`
+- `ethereumjs-config-lint-fix`
+
+## Usage
+
+Add `tslint.json`:
+
+```json
+{
+  "extends": "@ethereumjs/config-tslint"
+}
+```
+
+Use CLI commands above in `package.json`:
+
+```json
+  "scripts": {
+    "tslint": "ethereumjs-config-tslint",
+    "tslint-fix": "ethereumjs-config-tslint-fix",
+    "lint": "ethereumjs-config-lint",
+    "lint-fix": "ethereumjs-config-lint-fix"
+  }
+```
+
+
+

--- a/packages/ethereumjs-config-tslint/cli/lint-fix.sh
+++ b/packages/ethereumjs-config-tslint/cli/lint-fix.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec npm run format:fix && exec npm run tslint:fix && exec npm run tsc

--- a/packages/ethereumjs-config-tslint/cli/lint.sh
+++ b/packages/ethereumjs-config-tslint/cli/lint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec npm run format && exec npm run tslint && exec npm run tsc

--- a/packages/ethereumjs-config-tslint/cli/tslint-fix.sh
+++ b/packages/ethereumjs-config-tslint/cli/tslint-fix.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tslint --fix --format stylish -p ./tsconfig.json -e 'node_modules/**/*' -e '**/node_modules/**/*' -e 'dist/**/*' **/*.ts

--- a/packages/ethereumjs-config-tslint/cli/tslint.sh
+++ b/packages/ethereumjs-config-tslint/cli/tslint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tslint -p ./tsconfig.json -e 'node_modules/**/*' -e '**/node_modules/**/*' -e 'dist/**/*' **/*.ts

--- a/packages/ethereumjs-config-tslint/package.json
+++ b/packages/ethereumjs-config-tslint/package.json
@@ -6,8 +6,15 @@
   "repository": "git@github.com:ethereumjs/ethereumjs-config.git",
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
-    "tslint.json"
+    "tslint.json",
+    "cli"
   ],
+  "bin": {
+    "ethereumjs-config-tslint": "./cli/tslint.sh",
+    "ethereumjs-config-tslint-fix": "./cli/tslint-fix.sh",
+    "ethereumjs-config-lint": "./cli/lint.sh",
+    "ethereumjs-config-lint-fix": "./cli/lint-fix.sh"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Ok, this would be my take on this, should be relatively self-explanatory due to added `README` instructions. 

Output comes as stream in chunks, so this should also work pleasantly for longer-running commands.

Tested this locally on the `ethereumjs-common` library.

Have only done this for `Prettier` as a PoC but would extend to other packages after first review/feedback.

Fixes #12 and #10.