### PR TITLE
Add Installation section to config-tslint's README.md

### DIFF
--- a/packages/ethereumjs-config-tslint/README.md
+++ b/packages/ethereumjs-config-tslint/README.md
@@ -34,5 +34,7 @@ Use CLI commands above in `package.json`:
   }
 ```
 
+## Installation
 
+This package requires [`typestrict`](https://github.com/krzkaczor/TypeStrict) to be installed.
 


### PR DESCRIPTION
This package requires `typestrict` to be installed. If not, tslint fails with a confusing error message. I added a note about it.