### PR TITLE
Upgrade primary build target to ES2017, add browser build

### DIFF
--- a/packages/coverage/README.md
+++ b/packages/coverage/README.md
@@ -4,8 +4,6 @@ Common test coverage configuration for `EthereumJS` libraries.
 
 Tool: [nyc](https://istanbul.js.org/)
 
-Supported Version: `^11.7.0`
-
 Exposed CLI command:
 
 - `ethereumjs-config-coverage`

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -4,8 +4,6 @@ Common formatting configuration for `EthereumJS` libraries.
 
 Tool: [Prettier](https://prettier.io/)
 
-Supported Version: `^1.15.3`
-
 Exposed CLI commands:
 
 - `ethereumjs-config-format`
@@ -16,7 +14,7 @@ Exposed CLI commands:
 Add `prettier.config.js`:
 
 ```javascript
-module.exports = require('@ethereumjs/config-format')
+module.exports = require('@ethereumjs/config-format');
 ```
 
 Add `.prettierignore`:

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -4,8 +4,6 @@ Common `TypeScript` configuration for `EthereumJS` libraries.
 
 Tool: [TypeScript](https://www.typescriptlang.org/)
 
-Supported Version: `^3.2.2`
-
 Exposed CLI commands:
 
 - `ethereumjs-config-ts-compile`

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -15,7 +15,7 @@ Add `tsconfig.json`:
 
 ```json
 {
-  "extends": "@ethereumjs/config-typescript",
+  "extends": "@ethereumjs/config-typescript/tsconfig.json",
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }
 ```
@@ -24,15 +24,21 @@ Add `tsconfig.prod.json`:
 
 ```json
 {
-  "extends": "@ethereumjs/config-typescript",
-  "compilerOptions": {
-    "outDir": "./dist"
-  },
+  "extends": "@ethereumjs/config-typescript/tsconfig.prod.json",
   "include": ["src/**/*.ts"]
 }
 ```
 
-Use CLI commands above in `package.json`:
+Add `tsconfig.browser.json`:
+
+```json
+{
+  "extends": "@ethereumjs/config-typescript/tsconfig.browser.json",
+  "include": ["src/**/*.ts"]
+}
+```
+
+Use CLI commands above in your `package.json`:
 
 ```json
   "scripts": {
@@ -41,5 +47,14 @@ Use CLI commands above in `package.json`:
   }
 ```
 
+The default production target is ES2017. To support shipping the ES5 target for browsers, add to your `package.json`:
 
-
+```json
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "browser": "dist.browser/index.js",
+  "files": [
+    "dist",
+    "dist.browser"
+  ]
+```

--- a/packages/typescript/cli/ts-build.sh
+++ b/packages/typescript/cli/ts-build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+set -e
 set -o xtrace
 tsc -p ./tsconfig.prod.json && test -f ./tsconfig.browser.json && tsc -p ./tsconfig.browser.json

--- a/packages/typescript/cli/ts-build.sh
+++ b/packages/typescript/cli/ts-build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -o xtrace
-exec tsc -p ./tsconfig.prod.json
+tsc -p ./tsconfig.prod.json && test -f ./tsconfig.browser.json && tsc -p ./tsconfig.browser.json

--- a/packages/typescript/cli/ts-compile.sh
+++ b/packages/typescript/cli/ts-compile.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -o xtrace
-tsc -p ./tsconfig.json
+tsc -p ./tsconfig.json --noEmit

--- a/packages/typescript/cli/ts-compile.sh
+++ b/packages/typescript/cli/ts-compile.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -o xtrace
-exec tsc --noEmit
+tsc -p ./tsconfig.json

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -7,6 +7,8 @@
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
     "tsconfig.json",
+    "tsconfig.prod.json",
+    "tsconfig.browser.json",
     "cli"
   ],
   "bin": {

--- a/packages/typescript/tsconfig.browser.json
+++ b/packages/typescript/tsconfig.browser.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist.browser",
+    "target": "es5",
+    "lib": ["dom", "es5"]
+  }
+}

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -11,7 +11,7 @@
     "resolveJsonModule": true,
     "downlevelIteration": true,
     "strict": true,
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["es2018"]
   }
 }

--- a/packages/typescript/tsconfig.prod.json
+++ b/packages/typescript/tsconfig.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}


### PR DESCRIPTION
This PR is a **breaking change** and upgrades the primary typescript build target to ES2017 and adds a ES5 browser build as inspired by https://github.com/ethereumjs/merkle-patricia-tree/pull/117 and https://github.com/ethereumjs/ethereumjs-vm/pull/603.

See the [readme](https://github.com/ethereumjs/ethereumjs-config/blob/61f05e97b07daaf56c8a6f76673033bff27804d9/packages/typescript/README.md#usage) on how to dependent libraries should update their usage.