### PR TITLE
Rename lint config

### DIFF
--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -18,7 +18,7 @@ Add `.eslintrc.js`:
 
 ```js
 module.exports = {
-  extends: "@ethereumjs/config-lint"
+  extends: "@ethereumjs/eslint-config-helper"
 }
 ```
 
@@ -30,3 +30,6 @@ Use CLI commands above in your `package.json`:
     "lint:fix": "ethereumjs-config-lint-fix",
   }
 ```
+
+
+_Note: The name of this package deviates from the standard @ethereumjs/config-xxx, due to an ESLint hard rule on package naming. [Reference](https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules)._

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ethereumjs/config-lint",
+  "name": "@ethereumjs/eslint-config-helper",
   "version": "2.0.0",
   "main": ".eslintrc.js",
   "license": "MIT",


### PR DESCRIPTION
The ESLint rule below sets a hard requirement on this package name.
https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules

