### PR TITLE
Lint return value

### DIFF
--- a/packages/coverage/CHANGELOG.md
+++ b/packages/coverage/CHANGELOG.md
@@ -6,13 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED] - 2020-08-25
+## [2.0.0] - 2020-10-08
 
-This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts. Below is a breakdown by package.
+This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts.
 
 **Breaking changes**
 
-- Renamed package `@ethereumjs/config-nyc` => [`@ethereumjs/config-coverage`](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/coverage)
+- Renamed package `@ethereumjs/config-nyc` => [`@ethereumjs/config-coverage`](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/coverage), PR [#27](https://github.com/ethereumjs/ethereumjs-config/pull/27)
 - The platform-specific script `ethereumjs-config-coveralls` got removed, due to the use of Codecov and [nicer integration to GitHub CI](https://github.com/codecov/codecov-action).
 
 [2.0.0]: https://github.com/ethereumjs/ethereumjs-vm/compare/%40ethereumjs%2Fconfig%401.1.1...%40ethereumjs%2Fconfig%402.0.0

--- a/packages/coverage/package.json
+++ b/packages/coverage/package.json
@@ -7,7 +7,8 @@
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
     "nyc.json",
-    "cli"
+    "cli",
+    "README.md"
   ],
   "bin": {
     "ethereumjs-config-coverage": "./cli/coverage.sh"

--- a/packages/lint/CHANGELOG.md
+++ b/packages/lint/CHANGELOG.md
@@ -12,9 +12,10 @@ This project got a major overhaul, with several updates to the tooling, includin
 
 **Breaking changes**
 
-- This package got renamed: `@ethereumjs/config-tslint` => [`@ethereumjs/eslint-config-defaults`](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/lint)
+- This package got renamed: `@ethereumjs/config-tslint` => [`@ethereumjs/eslint-config-defaults`](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/lint), PRs [#29](https://github.com/ethereumjs/ethereumjs-config/pull/29), [#32](https://github.com/ethereumjs/ethereumjs-config/pull/32)
+- Updated shell scripts and overall configuration, PR [#34](https://github.com/ethereumjs/ethereumjs-config/pull/34)
 
-Following the deprecation of the [TSLint project](https://palantir.github.io/tslint/) by Palantir, we moved on to ESLint, that have integrations with TypeScript and Prettier.
+Following the deprecation of the [TSLint project](https://palantir.github.io/tslint/) by Palantir, we moved on to ESLint, that allows us to better integrate with TypeScript and Prettier.
 - `@ethereumjs/config-tslint` got renamed to `@ethereumjs/eslint-config-defaults`
 - Removal of scripts `ethereumjs-config-tslint` and `ethereumjs-config-tslint-fix`
 - Added TypeScript ESLint

--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -22,6 +22,12 @@ module.exports = {
 }
 ```
 
+Add `prettier.config.js`:
+
+```js
+module.exports = require('@ethereumjs/eslint-config-defaults/prettier.config.js')
+```
+
 Use CLI commands above in your `package.json`:
 
 ```json

--- a/packages/lint/cli/lint-fix.sh
+++ b/packages/lint/cli/lint-fix.sh
@@ -50,7 +50,7 @@ dim() {
 
 dim "> eslint --fix --config ./.eslintrc.js . \\ "
 dim "\t --ext .js,.jsx,.ts,.tsx \\ "
-dim "\t --resolve-plugins-relative-to $(package_path)\n"
+dim "\t --resolve-plugins-relative-to $(package_path)"
 
 blue "[Lint]${NOCOLOR} fixing..."
 
@@ -59,7 +59,7 @@ eslint --fix --config ./.eslintrc.js . --ext .js,.jsx,.ts,.tsx --resolve-plugins
 RETURN_CODE=$?
 
 if [ $RETURN_CODE -eq 0 ]; then
-    blue "[Lint]${GREEN} DONE.\n"
+    blue "[Lint]${GREEN} DONE."
 else
     exit $RETURN_CODE
 fi

--- a/packages/lint/cli/lint-fix.sh
+++ b/packages/lint/cli/lint-fix.sh
@@ -56,4 +56,10 @@ blue "[Lint]${NOCOLOR} fixing..."
 
 eslint --fix --config ./.eslintrc.js . --ext .js,.jsx,.ts,.tsx --resolve-plugins-relative-to $(package_path)
 
-blue "[Lint]${GREEN} DONE.\n"
+RETURN_CODE=$?
+
+if [ $RETURN_CODE -eq 0 ]; then
+    blue "[Lint]${GREEN} DONE.\n"
+else
+    exit $RETURN_CODE
+fi

--- a/packages/lint/cli/lint.sh
+++ b/packages/lint/cli/lint.sh
@@ -50,7 +50,7 @@ dim() {
 
 dim "> eslint --format codeframe --config ./.eslintrc.js . \\ "
 dim "\t --ext .js,.jsx,.ts,.tsx \\ "
-dim "\t --resolve-plugins-relative-to $(package_path)\n"
+dim "\t --resolve-plugins-relative-to $(package_path)"
 
 blue "[Lint]${NOCOLOR} checking..."
 
@@ -59,7 +59,7 @@ eslint --format codeframe --config ./.eslintrc.js . --ext .js,.jsx,.ts,.tsx --re
 RETURN_CODE=$?
 
 if [ $RETURN_CODE -eq 0 ]; then
-    blue "[Lint]${GREEN} DONE.\n"
+    blue "[Lint]${GREEN} DONE."
 else
     exit $RETURN_CODE
 fi

--- a/packages/lint/cli/lint.sh
+++ b/packages/lint/cli/lint.sh
@@ -56,4 +56,10 @@ blue "[Lint]${NOCOLOR} checking..."
 
 eslint --format codeframe --config ./.eslintrc.js . --ext .js,.jsx,.ts,.tsx --resolve-plugins-relative-to $(package_path)
 
-blue "[Lint]${GREEN} DONE.\n"
+RETURN_CODE=$?
+
+if [ $RETURN_CODE -eq 0 ]; then
+    blue "[Lint]${GREEN} DONE.\n"
+else
+    exit $RETURN_CODE
+fi

--- a/packages/lint/index.js
+++ b/packages/lint/index.js
@@ -5,7 +5,7 @@ module.exports = {
     es6: true,
     node: true,
   },
-  ignorePatterns: ['node_modules/', 'dist/', 'dist.browser/', 'coverage/', 'prettier.config.js', 'typedoc.js', 'test-build/', ''],
+  ignorePatterns: ['node_modules/', 'dist/', 'dist.browser/', 'coverage/', 'prettier.config.js', 'typedoc.js', 'test-build/', 'karma.conf.js'],
   extends: ['typestrict', 'eslint:recommended'],
   rules: {
     'no-console': 'warn',

--- a/packages/lint/index.js
+++ b/packages/lint/index.js
@@ -5,7 +5,7 @@ module.exports = {
     es6: true,
     node: true,
   },
-  ignorePatterns: ['node_modules/**/*', 'dist*/**/*', 'coverage/', 'prettier.config.js', 'typedoc.js'],
+  ignorePatterns: ['node_modules/', 'dist/', 'dist.browser/', 'coverage/', 'prettier.config.js', 'typedoc.js', 'test-build/', ''],
   extends: ['typestrict', 'eslint:recommended'],
   rules: {
     'no-console': 'warn',

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -7,7 +7,9 @@
   "author": "Krzysztof Kaczor <chris@kaczor.io>",
   "files": [
     "index.js",
-    "cli"
+    "cli",
+    "prettier.config.js",
+    "README.md"
   ],
   "bin": {
     "ethereumjs-config-lint": "./cli/lint.sh",

--- a/packages/lint/prettier.config.js
+++ b/packages/lint/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    semi: false,
+    singleQuote: true,
+    printWidth: 100
+}

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED] - 2020-08-25
+## [2.0.0] - 2020-10-08
 
-This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts. Below is a breakdown by package.
+This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts.
 
 **Breaking changes**
 
-- Package renamed: `@ethereumjs/config-tsc` => [`@ethereumjs/config-typescript`](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/typescript ), to become more tool agnostic
-- Added TypeScript compiler config file for targeting the browser
+- Package renamed: `@ethereumjs/config-tsc` => [`@ethereumjs/config-typescript`](https://github.com/ethereumjs/ethereumjs-config/tree/master/packages/typescript ), to become more tool agnostic, PR [#27](https://github.com/ethereumjs/ethereumjs-config/pull/27)
+- Added TypeScript compiler config file for targeting the browser, PR [#28](https://github.com/ethereumjs/ethereumjs-config/pull/28)
 
 [2.0.0]: https://github.com/ethereumjs/ethereumjs-vm/compare/%40ethereumjs%2Fconfig%401.1.1...%40ethereumjs%2Fconfig%402.0.0
 

--- a/packages/typescript/cli/ts-build.sh
+++ b/packages/typescript/cli/ts-build.sh
@@ -40,7 +40,7 @@ printf "${BLUE}[Node build] Working... "
 tsc -p ./tsconfig.prod.json
 green "DONE"
 
-echo "\n\n";
+echo "\n";
 
 if [ -f ./tsconfig.browser.json ];
 then
@@ -52,9 +52,14 @@ then
     printf "Working... "
 
     tsc -p ./tsconfig.browser.json
-    green "DONE\n\n"
+    RETURN_CODE=$?
 
+    if [ $RETURN_CODE -eq 0 ]; then
+        green "DONE"
+    else
+        exit $RETURN_CODE
+    fi
 else
-    dim "Skipping browser build, because no tsconfig.browser.json file is present.\n"
+    dim "Skipping browser build, because no tsconfig.browser.json file is present."
 fi
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -9,7 +9,8 @@
     "tsconfig.json",
     "tsconfig.prod.json",
     "tsconfig.browser.json",
-    "cli"
+    "cli",
+    "README.md"
   ],
   "bin": {
     "ethereumjs-config-ts-compile": "./cli/ts-compile.sh",

--- a/scripts/ethereumjs-config-localdev.sh
+++ b/scripts/ethereumjs-config-localdev.sh
@@ -4,10 +4,20 @@
 
 npm remove @ethereumjs/config-nyc @ethereumjs/config-tsc @ethereumjs/config-prettier @ethereumjs/config-tslint
 
-ETHEREUMJS_CONFIG_PATH=/Users/evertonfraga/Projects/Ethereum/ethereumjs-config
+ETHEREUMJS_CONFIG_PATH=/Users/evertonfraga/Projects/Ethereum/ethereumjs-config/packages
+
+PROJECT_PWD=`pwd`
+
+cd $ETHEREUMJS_CONFIG_PATH/coverage && npm link
+cd $ETHEREUMJS_CONFIG_PATH/typescript && npm link
+cd $ETHEREUMJS_CONFIG_PATH/lint && npm link
+
+cd $PROJECT_PWD
+npm link @ethereumjs/config-coverage
+npm link @ethereumjs/config-typescript
+npm link @ethereumjs/eslint-config-defaults
 
 npm i --save-dev \
   @ethereumjs/config-coverage@file:$ETHEREUMJS_CONFIG_PATH/packages/coverage \
   @ethereumjs/config-typescript@file:$ETHEREUMJS_CONFIG_PATH/packages/typescript \
-  @ethereumjs/config-format@file:$ETHEREUMJS_CONFIG_PATH/packages/format \
-  @ethereumjs/eslint-config-defaults@file:$ETHEREUMJS_CONFIG_PATH/packages/lint
+  @ethereumjs/eslint-config-helper@file:$ETHEREUMJS_CONFIG_PATH/packages/lint

--- a/scripts/migrate-ethereumjs-config.sh
+++ b/scripts/migrate-ethereumjs-config.sh
@@ -6,10 +6,10 @@
 
 npm remove @ethereumjs/config-nyc @ethereumjs/config-tsc @ethereumjs/config-prettier @ethereumjs/config-tslint
 
-npm i --save-dev @ethereumjs/config-coverage \
-                 @ethereumjs/config-typescript \
-                 @ethereumjs/config-format \
-                 @ethereumjs/eslint-config-helper \
+npm i --save-dev @ethereumjs/config-coverage @ethereumjs/config-typescript @ethereumjs/eslint-config-defaults
+
+npm i --save-dev @typescript-eslint/eslint-plugin eslint-config-prettier eslint-plugin-implicit-dependencies
+
 
 # 2. Some scripts had changed name
 
@@ -18,6 +18,9 @@ sed -E -e 's/ethereumjs\-config\-tsc/ethereumjs-config-ts-compile/' -ibak packag
 
 # ethereumjs-config-build -> ethereumjs-config-ts-build
 sed -E -e 's/ethereumjs\-config\-build/ethereumjs-config-ts-build/' -ibak package.json
+
+
+npm i --save-dev eslint@6
 
 
 # 3. Some scripts are just gone
@@ -30,3 +33,12 @@ grep -EHn "ethereumjs-config-coveralls" package.json
 # ethereumjs-config-lint -> ☠️
 # ethereumjs-config-lint-fix -> ☠️
 grep -EHn "ethereumjs-config-tslint(-fix)?" package.json
+
+grep -EHn "tsc" tslint*.json
+
+
+# 4. Health check
+npm run build
+npm run lint
+npm run lint:fix
+npm run coverage


### PR DESCRIPTION
When there's a failure on the linting script, forwards the respective exit code to the parent process.

This change makes the CI fail when there's a lint failure. I have decided to handle those errors/failures manually, so we can have better messages, overall.