### PR TITLE
Use positional path in lint scripts

### DIFF
--- a/packages/lint/cli/lint-fix.sh
+++ b/packages/lint/cli/lint-fix.sh
@@ -23,7 +23,7 @@
 
 package_path() {
     # canonical path of this script, resolving symlinks
-    REALPATH_SCRIPT=$(realpath $BASH_SOURCE)
+    REALPATH_SCRIPT=$(realpath $0)
 
     # going up one directory, towards the lint package dir.
     LINT_PACKAGE_DIRECTORY=$(dirname $(dirname ${REALPATH_SCRIPT}))

--- a/packages/lint/cli/lint.sh
+++ b/packages/lint/cli/lint.sh
@@ -23,7 +23,7 @@
 
 package_path() {
     # canonical path of this script, resolving symlinks
-    REALPATH_SCRIPT=$(realpath $BASH_SOURCE)
+    REALPATH_SCRIPT=$(realpath $0)
 
     # going up one directory, towards the lint package dir.
     LINT_PACKAGE_DIRECTORY=$(dirname $(dirname ${REALPATH_SCRIPT}))


### PR DESCRIPTION
Attempt to fix https://github.com/ethereumjs/ethereumjs-vm/pull/913, will trigger a test run there.