### PR TITLE
v2.0.0 Releases of the libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,5 @@ Bootstrapping:
 lerna bootstrap
 ```
 
-Publication with 2FA enabled:
+Publication is done manually with `npm publish` from the package directories.
 
-```sh
-NPM_CONFIG_OTP=123456 lerna publish
-```

--- a/packages/coverage/CHANGELOG.md
+++ b/packages/coverage/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2020-10-08
+## [2.0.0] - 2020-10-19
 
 This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts.
 

--- a/packages/lint/CHANGELOG.md
+++ b/packages/lint/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED] - 2020-08-25
+## [2.0.0] - 2020-08-25
 
 This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts. Below is a breakdown by package.
 

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2020-10-08
+## [2.0.0] - 2020-10-19
 
 This project got a major overhaul, with several updates to the tooling, including packages renaming and retiring some scripts.
 


### PR DESCRIPTION
Ok, I would now do the `v2.0.0` releases of the libraries. `package.json` version numbers are already bumped, so this PR only updates CHANGELOG entries, this is also to have a dedicated release PR.

I checked the package contents with `npm pack` - this looks good - and would do the releases manually from the package directories with `npm publish`. Let me know if you have got any comments here.