### PR TITLE
Add prefer nullish coalescing rule

### DIFF
--- a/packages/lint/index.js
+++ b/packages/lint/index.js
@@ -16,6 +16,7 @@ module.exports = {
       'error',
       { peer: true, dev: true, optional: true },
     ],
+    '@typescript-eslint/prefer-nullish-coalescing': 'error',
     '@typescript-eslint/no-use-before-define': 'error',
     '@typescript-eslint/interface-name-prefix': [
       'error',


### PR DESCRIPTION
I turned on [prefer-nullish-coalescing](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md) rule on. It prescribes to use [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) (`??`) to be used instead of ternary condition. It makes code shorter and better understandable.

**Wrong Code**:
```ts
const a
const b = a === undefined ? a : 'A is null or undefined'
```

**Correct Code**:
```ts
const a
const b = a ?? 'A is null or undefined'
```
