### PR TITLE
Target Node 12

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -18,5 +18,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@tsconfig/node12": "^1.0.7"
   }
 }

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -1,17 +1,13 @@
 {
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
     "sourceMap": true,
     "declaration": true,
-    "module": "commonjs",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "downlevelIteration": true,
-    "strict": true,
-    "target": "ES2017",
-    "lib": ["es2018"]
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
Targets Node 12 using `@tsconfig/node12`. I initially tried Node 14 (which gave better build output), but then dropped to 12 after being concerned for losing compatibility. Before the change it was 8-10-ish, but both versions reached EOL.